### PR TITLE
feat: field longitude and latitude in property form

### DIFF
--- a/components/properties/columns.tsx
+++ b/components/properties/columns.tsx
@@ -99,6 +99,26 @@ export const createColumns = ({
     },
   },
   {
+    accessorKey: "coordinates",
+    header: "Coordinates",
+    cell: ({ row }) => {
+      const property = row.original
+      const hasCoordinates = property.longitude !== undefined && property.latitude !== undefined
+      return (
+        <div className="text-sm">
+          {hasCoordinates ? (
+            <div>
+              <div className="font-mono text-xs">{property.latitude?.toFixed(4)}</div>
+              <div className="font-mono text-xs text-muted-foreground">{property.longitude?.toFixed(4)}</div>
+            </div>
+          ) : (
+            <span className="text-muted-foreground">-</span>
+          )}
+        </div>
+      )
+    },
+  },
+  {
     accessorKey: "bedrooms",
     header: ({ column }) => {
       return (

--- a/config/property-form-config.ts
+++ b/config/property-form-config.ts
@@ -28,69 +28,74 @@ export const defaultPropertyFormConfig: PropertyFormConfig = {
   landmark: { required: false, visible: true, order: 11, group: "location" },
   houseId: { required: false, visible: true, order: 12, group: "location" },
   
-  // Property Specifications (Group 4)
-  size: { required: true, visible: true, order: 13, group: "specs" },
-  bedrooms: { required: true, visible: true, order: 14, group: "specs" },
-  bathroom: { required: true, visible: true, order: 15, group: "specs" },
-  baranda: { required: false, visible: true, order: 16, group: "specs" },
-  floor: { required: false, visible: true, order: 17, group: "specs" },
-  totalFloor: { required: false, visible: true, order: 18, group: "specs" },
-  apartmentType: { required: false, visible: true, order: 19, group: "specs" },
+  // Map Information (Group 4)
+  latitude: { required: false, visible: true, order: 13, group: "map" },
+  longitude: { required: false, visible: true, order: 14, group: "map" },
   
-  // Furnishing & Category (Group 5)
-  category: { required: true, visible: true, order: 20, group: "furnishing" },
-  furnishingStatus: { required: false, visible: true, order: 21, group: "furnishing" },
+  // Property Specifications (Group 5)
+  size: { required: true, visible: true, order: 15, group: "specs" },
+  bedrooms: { required: true, visible: true, order: 16, group: "specs" },
+  bathroom: { required: true, visible: true, order: 17, group: "specs" },
+  baranda: { required: false, visible: true, order: 18, group: "specs" },
+  floor: { required: false, visible: true, order: 19, group: "specs" },
+  totalFloor: { required: false, visible: true, order: 20, group: "specs" },
+  apartmentType: { required: false, visible: true, order: 21, group: "specs" },
   
-  // Rental Information (Group 6)
-  inventoryStatus: { required: false, visible: true, order: 22, group: "rental" },
-  tenantType: { required: false, visible: true, order: 23, group: "rental" },
-  availableFrom: { required: false, visible: true, order: 24, group: "rental" },
-  rent: { required: false, visible: true, order: 25, group: "rental" },
-  serviceCharge: { required: false, visible: true, order: 26, group: "rental" },
-  advanceMonths: { required: false, visible: true, order: 27, group: "rental" },
+  // Furnishing & Category (Group 6)
+  category: { required: true, visible: true, order: 22, group: "furnishing" },
+  furnishingStatus: { required: false, visible: true, order: 23, group: "furnishing" },
   
-  // Property Details (Group 7)
-  yearOfConstruction: { required: false, visible: true, order: 28, group: "details" },
-  listingId: { required: false, visible: true, order: 29, group: "details" },
+  // Rental Information (Group 7)
+  inventoryStatus: { required: false, visible: true, order: 24, group: "rental" },
+  tenantType: { required: false, visible: true, order: 25, group: "rental" },
+  availableFrom: { required: false, visible: true, order: 26, group: "rental" },
+  rent: { required: false, visible: true, order: 27, group: "rental" },
+  serviceCharge: { required: false, visible: true, order: 28, group: "rental" },
+  advanceMonths: { required: false, visible: true, order: 29, group: "rental" },
   
-  // Amenities Scores (Group 8)
-  cleanHygieneScore: { required: false, visible: true, order: 30, group: "amenities" },
-  sunlightScore: { required: false, visible: true, order: 31, group: "amenities" },
-  bathroomConditionsScore: { required: false, visible: true, order: 32, group: "amenities" },
+  // Property Details (Group 8)
+  yearOfConstruction: { required: false, visible: true, order: 30, group: "details" },
+  listingId: { required: false, visible: true, order: 31, group: "details" },
   
-  // Facilities (Group 9 - Boolean checkboxes)
-  lift: { required: false, visible: true, order: 33, group: "facilities" },
-  cctv: { required: false, visible: true, order: 34, group: "facilities" },
-  communityHall: { required: false, visible: true, order: 35, group: "facilities" },
-  gym: { required: false, visible: true, order: 36, group: "facilities" },
-  masjid: { required: false, visible: true, order: 37, group: "facilities" },
-  parking: { required: false, visible: true, order: 38, group: "facilities" },
-  petsAllowed: { required: false, visible: true, order: 39, group: "facilities" },
-  swimmingPool: { required: false, visible: true, order: 40, group: "facilities" },
-  trainedGuard: { required: false, visible: true, order: 41, group: "facilities" },
+  // Amenities Scores (Group 9)
+  cleanHygieneScore: { required: false, visible: true, order: 32, group: "amenities" },
+  sunlightScore: { required: false, visible: true, order: 33, group: "amenities" },
+  bathroomConditionsScore: { required: false, visible: true, order: 34, group: "amenities" },
   
-  // Property Status (Group 10)
-  firstOwner: { required: false, visible: true, order: 42, group: "status" },
-  paperworkUpdated: { required: false, visible: true, order: 43, group: "status" },
-  onLoan: { required: false, visible: true, order: 44, group: "status" },
-  isConfirmed: { required: false, visible: true, order: 45, group: "status" },
-  isVerified: { required: false, visible: true, order: 46, group: "status" },
+  // Facilities (Group 10 - Boolean checkboxes)
+  lift: { required: false, visible: true, order: 35, group: "facilities" },
+  cctv: { required: false, visible: true, order: 36, group: "facilities" },
+  communityHall: { required: false, visible: true, order: 37, group: "facilities" },
+  gym: { required: false, visible: true, order: 38, group: "facilities" },
+  masjid: { required: false, visible: true, order: 39, group: "facilities" },
+  parking: { required: false, visible: true, order: 40, group: "facilities" },
+  petsAllowed: { required: false, visible: true, order: 41, group: "facilities" },
+  swimmingPool: { required: false, visible: true, order: 42, group: "facilities" },
+  trainedGuard: { required: false, visible: true, order: 43, group: "facilities" },
   
-  // Images (Group 11)
-  coverImage: { required: false, visible: true, order: 47, group: "images" },
-  otherImages: { required: false, visible: true, order: 48, group: "images" },
+  // Property Status (Group 11)
+  firstOwner: { required: false, visible: true, order: 44, group: "status" },
+  paperworkUpdated: { required: false, visible: true, order: 45, group: "status" },
+  onLoan: { required: false, visible: true, order: 46, group: "status" },
+  isConfirmed: { required: false, visible: true, order: 47, group: "status" },
+  isVerified: { required: false, visible: true, order: 48, group: "status" },
   
-  // Notes (Group 12)
-  notes: { required: false, visible: true, order: 49, group: "notes" },
+  // Images (Group 12)
+  coverImage: { required: false, visible: true, order: 49, group: "images" },
+  otherImages: { required: false, visible: true, order: 50, group: "images" },
   
-  // Property Value History (Group 13)
-  propertyValueHistory: { required: false, visible: true, order: 50, group: "valueHistory" },
+  // Notes (Group 13)
+  notes: { required: false, visible: true, order: 51, group: "notes" },
+  
+  // Property Value History (Group 14)
+  propertyValueHistory: { required: false, visible: true, order: 52, group: "valueHistory" },
 };
 
 export const formGroupLabels = {
   basic: "Basic Information",
   property: "Property Details", 
   location: "Location Information",
+  map: "Map Information",
   specs: "Property Specifications",
   furnishing: "Furnishing Details",
   rental: "Rental Information",
@@ -107,6 +112,7 @@ export const formGroupOrder = [
   "basic",
   "property", 
   "location",
+  "map",
   "specs",
   "furnishing",
   "rental",

--- a/lib/validations/property-form.ts
+++ b/lib/validations/property-form.ts
@@ -47,6 +47,11 @@ export const propertyFormSchema = z.object({
   houseId: z.string().max(50, "House ID must be less than 50 characters").optional(),
   streetAddress: z.string().max(500, "Street address must be less than 500 characters").optional(),
   landmark: z.string().max(300, "Landmark must be less than 300 characters").optional(),
+  
+  // GPS Coordinates - Optional
+  longitude: z.number().min(-180, "Longitude must be between -180 and 180").max(180, "Longitude must be between -180 and 180").optional(),
+  latitude: z.number().min(-90, "Latitude must be between -90 and 90").max(90, "Latitude must be between -90 and 90").optional(),
+  
   area: z.enum([
     "Aftabnagar", "Banani", "Banani DOHs", "Banashree", "Banasree", "Baridhara DOHs", 
     "Baridhara J Block", "Bashundhara Residential", "Dhanmondi", "DIT & Merul Badda", 

--- a/types/index.ts
+++ b/types/index.ts
@@ -92,6 +92,10 @@ export interface Property {
   landmark?: string
   area?: Area
   listingId?: string
+  
+  // GPS Coordinates
+  longitude?: number
+  latitude?: number
   inventoryStatus?: InventoryStatus
   tenantType?: TenantType
   propertyCategory?: PropertyCategory


### PR DESCRIPTION
# Feature: Add GPS Coordinates Support

This PR introduces new fields for GPS coordinates (longitude and latitude) to the property form, validation for these fields, and a new 'Coordinates' column to the property table.

## Changes

- **Added `longitude` and `latitude`** fields to the `Property` interface (`types/index.ts`).
- **Implemented Zod validation** for `longitude` and `latitude` to ensure valid numerical ranges (`-180` to `180` and `-90` to `90` respectively) in `lib/validations/property-form.ts`.
- **Created a new form group "Map Information"** in `config/property-form-config.ts` and placed the coordinate fields within it, adjusting the order of subsequent groups.
- **Updated `PropertyForm` (`components/properties/property-form.tsx`):**
    - Added coordinate fields to `defaultValues`.
    - Implemented custom handling for `longitude` and `latitude` inputs to manage numerical type conversion and `undefined` state for empty inputs, ensuring a robust user experience for entering coordinates.
    - Set `mode: 'onChange'` for `useForm`.
    - Updated field labels and placeholders.
- **Added a new `Coordinates` column** to the properties table (`components/properties/columns.tsx`). This column displays the latitude and longitude (rounded to 4 decimal places) or a hyphen if coordinates are missing.